### PR TITLE
Update addon.py to properly handle unicode queries

### DIFF
--- a/plugin.audio.subKodi/addon.py
+++ b/plugin.audio.subKodi/addon.py
@@ -6,7 +6,7 @@ import urlparse
 import requests
 
 def build_url(query):
-    return base_url + '?' + urllib.urlencode(query)
+    return base_url + '?' + urllib.urlencode(dict([k.encode('utf-8'),unicode(v).encode('utf-8')] for k,v in query.items()))
 
 
 class Subsonic(object):


### PR DESCRIPTION
Method build_url(query) wouldn't handle extra unicode characters (in artist name for instance).
Following fix did the trick as far as I'm concerned.
